### PR TITLE
backport: Add 8.4 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -128,3 +128,15 @@ pull_request_rules:
         message: |
           This pull request has been automatically closed by Mergify.
           There are likely new up-to-date and open pull requests.
+  - name: backport patches to 8.4 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-v8.4.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.4"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
Merge as soon as 8.4 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821